### PR TITLE
Change github workflow to use latest hugo version

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: "0.119.0"
+          hugo-version: "latest"
           extended: true
 
       - name: Build


### PR DESCRIPTION
While dependabot can detect versions updates of the action, it does not update the version of the installed versions. So we switch to latest to not have to do this manually over and over.